### PR TITLE
remove shadowDatabaseUrl

### DIFF
--- a/prisma/schema_copy.prisma
+++ b/prisma/schema_copy.prisma
@@ -2,7 +2,6 @@ datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL")
     directUrl         = env("POSTGRES_URL_NON_POOLING")
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
 generator client {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.